### PR TITLE
Prepare to the next release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 
 docker:
 	@echo ">> building docker image"
-	docker build -t "$(DOCKER_IMAGE_NAME):$(VERSION)"
+	docker build -t "$(DOCKER_IMAGE_NAME):$(VERSION)" .
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 DOCKER_IMAGE_NAME ?= mongodbatlas-exporter
-DOCKER_IMAGE_TAG ?= 0.0.1
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 BIN_DIR=.
 BIN=mongodbatlas_exporter
+VERSION=$(shell git describe --exact-match --tags HEAD || echo "latest")
+REVISION=$(shell git rev-parse HEAD)
+BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 .PHONY: test
 
@@ -11,7 +13,9 @@ test:
 
 docker:
 	@echo ">> building docker image"
-	docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+	docker build -t "$(DOCKER_IMAGE_NAME):$(VERSION)"
 
 build:
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $(BIN_DIR)/$(BIN) .
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+	-ldflags="-w -s -X github.com/prometheus/common/version.Branch=${BRANCH} -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.Version=${VERSION}" \
+	-o $(BIN_DIR)/$(BIN)

--- a/main.go
+++ b/main.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	name       = "mongodbatlas_exporter"
-	appVersion = "0.0.1"
+	name = "mongodbatlas_exporter"
 )
 
 var (
@@ -38,7 +37,7 @@ var (
 )
 
 func main() {
-	kingpin.Version(appVersion)
+	kingpin.Version(version.Print(name))
 	kingpin.Parse()
 
 	logger, err := createLogger(*logLevel)
@@ -47,8 +46,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	versionMetric := version.NewCollector(name)
-	prometheus.MustRegister(versionMetric)
+	prometheus.MustRegister(version.NewCollector(name))
 
 	client, err := mongodbatlas.NewClient(logger, *atlasPublicKey, *atlasPrivateKey, *atlasProjectID, *atlasClusters)
 	if err != nil {


### PR DESCRIPTION
- Improve versioning
- fix missing build_info
now `build_info` metric is:
```
mongodbatlas_exporter_build_info{branch="release",goversion="go1.16.8",revision="ee1332de7d93736df1bc3f66754fdd6b7aaea663",version="latest"} 1
```
before branch, revision and version labels were missing