### PR TITLE
add metric to count http requests

### DIFF
--- a/mongodbatlas/monitoring.go
+++ b/mongodbatlas/monitoring.go
@@ -1,0 +1,19 @@
+package mongodbatlas
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	requestCounter *prometheus.CounterVec
+)
+
+//when the package initializes HTTP client metrics are set here.
+func init() {
+	requestCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "mongodbatlas_http_requests_total",
+		Help: "the number of Atlas HTTP API requests made since startup",
+	},
+		[]string{"code", "method"},
+	)
+
+	prometheus.MustRegister(requestCounter)
+}


### PR DESCRIPTION
One of the biggest issues with scraping the Atlas API is getting rate limited. Using a simple HTTP counter we can better track the instances where rate limiting happens, but also see the total call volume being made per period.